### PR TITLE
Update faiss-cpu dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ fastapi==0.110.0
 uvicorn[standard]==0.29.0
 pandas==2.2.1
 scikit-learn==1.4.1.post1
-faiss-cpu==1.7.4
+faiss-cpu==1.11.0
 python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- bump faiss-cpu from 1.7.4 to 1.11.0 to use a wheel compatible with Python 3.11

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy., OSError('Tunnel connection failed: 403 Forbidden'))*

------
https://chatgpt.com/codex/tasks/task_e_68c9adf9e1e483258f8aa0d6d444af4b